### PR TITLE
Role uses stuff only available in 2.11 and above

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   company: troyfontaine.com
   license: MIT
   namespace: troyfontaine
-  min_ansible_version: "2.0"
+  min_ansible_version: "2.11"
   platforms:
     - name: Amazon
       versions:


### PR DESCRIPTION
# OVERVIEW

<!-- Describe what feature this pull request adds in a few sentences -->

FQCNs were not available until Ansible 2.9 and the `version_type` parameter to `version()` wasn't available until 2.11.

## WHY THE PULL REQUEST

<!-- Describe why this pull request should be merged, please justify the decisions made and what value it provides to the package -->

The role was broken on my Ansible version as it appeared it should work in 2.0 and above.

## HOW TO QA

Please provide some steps on how to QA this fix

1. Attempt to install role on Ansible 2.8 or lower.
2. See failures for FQCN.
3. Fix FQCN failures and see failure for `version_type`.

## SCREENSHOTS/EXAMPLES

<!-- These are optional but good to have -->

## Checklist

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests
